### PR TITLE
Remove Slack link

### DIFF
--- a/src/get-in-touch.md.njk
+++ b/src/get-in-touch.md.njk
@@ -7,10 +7,6 @@ show_subnav: false
 
 If you've got a question, idea or suggestion get in touch with the Design System team.
 
-## Slack
-
-Use the [#hm-land-registry channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=hm-land-registry).
-
 ## Email
 
 Email the Design System team on hmlr-design-system-support@landregistry.gov.uk


### PR DESCRIPTION
For initial go-live, we won't be monitoring our x-Gov Slack channel so email is the preferred method of contact.