### PR TITLE
Don't run tests in Windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Build & Test
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         include:
           - os: ubuntu-latest
             upload-artifact: ${{ inputs.upload-artifact }}


### PR DESCRIPTION
There is no current requirement for this design system to be developed on Windows machines so this will reduce the amount of time for the automated tests to run