### PR TITLE
Content/component page styling

### DIFF
--- a/src/components.md.njk
+++ b/src/components.md.njk
@@ -6,29 +6,27 @@ layout: layout-pane-no-nav.njk
 Components are reusable parts of the user interface. You can use the individual components in different patterns and contexts.
 
 You should:
-
 - use [GOV.UK Design System components](https://design-system.service.gov.uk/components/) where possible
-- create new or adapt Gov components only when you can demonstrate Gov ones do not work in your context
+- create new or adapt GOV.UK components only when you can demonstrate that GOV.UK ones do not work in your context
 - be sharing new and adapted components with the community
 
 Tell us what components you need so we prioritise getting them published.
 
-## Non Gov Design system components
+## Non GOV.UK Design System components
 
-Different patterns may be needed on HM Land Registry services and products depending on what domain they sit in and what kind of service it is.
+Different components may be needed on HM Land Registry services and products depending on what domain they sit in and what kind of service it is.
 
-### Land Registry design components
+### HM Land Registry Design System components
 
-If your service:
-- is internal, such as a caseworking system or admin service
+Use HM Land Registry Design System components if your service is internal, such as a caseworking or admin system.
 
-You should:
-- speak to caseworking designers, as they are documenting components and advice
+You should speak to designers working on casework systems, as they are documenting components and advice.
 
-### GOV.UK design components
+## GOV.UK design components
 
-If your service:
-- is public-facing and transactional, and
+Use GOV.UK design components if your service is all of the following:
+- public-facing
+- transactional
 - sits on a gov.uk or service.gov.uk domain
 
 You should:
@@ -42,7 +40,7 @@ Components that have been identified as needed or exist in more than one service
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {{ govukTable({
-  caption: "Pattern backlog",
+  caption: "Component backlog",
   captionClasses: "govuk-table__caption--m",
   firstCellIsHeader: true,
   head: [

--- a/src/patterns.md.njk
+++ b/src/patterns.md.njk
@@ -6,12 +6,12 @@ layout: layout-pane-no-nav.njk
 
 Patterns are best practice design solutions for specific user-focused tasks and page types.
 
-Patterns often use one or more [components](/components/) and explain how to adapt them to the context.
+Patterns often use one or more [components](/components/) and explain how to adapt them to your context.
 
 You should:
 
 - use [GOV.UK Design System patterns](https://design-system.service.gov.uk/patterns/) first
-- create new or adapt Gov patterns only when you can demonstrate Gov ones do not work in your context
+- create new or adapt GOV.UK patterns only when you can demonstrate GOV.UK ones do not work in your context
 - share new and adapted patterns with the [community](/community/)
 
 ## Patterns being worked on
@@ -205,4 +205,3 @@ Talk to the design system steering group to:
 - get access to the patterns documentation we have
 - find out how you can help
 - get advice on what to do if you think you have a new pattern, or need one
-

--- a/src/styles/index.md.njk
+++ b/src/styles/index.md.njk
@@ -5,26 +5,24 @@ layout: layout-pane.njk
 show_subnav: true
 ---
 
-We apply different styles to HM Land Registry services and products depending on what domain they sit in and what kind of service it is.
+We style HM Land Registry (HMLR) services in different ways depending on:
+  - what domain they're in
+  - who the service is for
+  - what kind of service it is
 
-## Land Registry design styles
+## HM Land Registry design styles
 
-If your service:
-- is internal, such as a caseworking system or admin service
-
-You should:
-- speak to caseworking designers, as they are developing advice and reusable elements
+Use HMLR design styles if your service is internal. For example, a caseworking or admin system.
+You should speak to designers working on casework systems for advice. They're developing reusable elements and advice.
 
 ---
 
 ## GOV.UK design styles
-
-If your service:
-- is public-facing and transactional, and
+Use GOV.UK design styles if your service is all of the following:
+- public-facing
+- transactional
 - sits on a gov.uk or service.gov.uk domain
 
 You should:
 - use [GOV.UK Design System styles](https://design-system.service.gov.uk/styles/)
-- speak to our service designers who work on GOV.UK services for any HM Land Registry adaptations
-
-
+- speak to our designers who work on GOV.UK services for any HM Land Registry adaptations

--- a/src/styles/typography/index.md.njk
+++ b/src/styles/typography/index.md.njk
@@ -23,4 +23,4 @@ HMLR have opted to use a typeface of Arial for our design system guidelines.
 
 Use Arial for our design system guidelines.
 
-For more help regarding typographic styles, please read the [GDS typography styles](https://design-system.service.gov.uk/styles/typography/).
+For more help regarding typographic styles, [read the GDS typography styles](https://design-system.service.gov.uk/styles/typography/).


### PR DESCRIPTION
This update refers to component, styles and pattern indexes. 
Update page content based on design system review. 
Change way we describe designers who work on casework systems.
Use bullet point guidelines. 
Update any references to Gov to GOV.UK.
Typography page - Use the action 'read' in the link text. 
Add 'HM' to Land Registry in relevant places.
Ensure consistency across the 3 sections.

